### PR TITLE
Use hash tags in lua keys for redis cluster

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ Object.assign(Lock.prototype, {
     this._scripty.loadScript('acquireScript', acquireScript, (err, script) => {
       if (err) return done(err);
 
-      script.run(2, `${this._namespace}:${id}`, `${this._namespace}index`, ttl, (err, evalResponse) => {
+      script.run(2, `{${this._namespace}}:${id}`, `{${this._namespace}}index`, ttl, (err, evalResponse) => {
         if (err) return done(err);
 
         var response = {
@@ -154,7 +154,7 @@ Object.assign(Lock.prototype, {
     this._scripty.loadScript('releaseScript', releaseScript, (err, script) => {
       if (err) return done(err);
 
-      script.run(1, `${this._namespace}:${lock.id}`, lock.index, (err, evalResponse) => {
+      script.run(1, `{${this._namespace}}:${lock.id}`, lock.index, (err, evalResponse) => {
         if (err) return done(err);
 
         var response = {


### PR DESCRIPTION
Redis clustering requires that all keys used within a lua script hash to the same shard. "Hash tags" are used to ensure that different keys with a common substring hash to the same shard. See https://redis.io/topics/cluster-spec

This change makes it so the namespace is the hash tag.