### PR TITLE
fix: handle redis client error events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ const redis = require('redis');
 const Scripty = require('node-redis-scripty');
 const { EventEmitter } = require('events');
 
+const noop = () => {};
+
 /**
  * Lock constructor.
  *
@@ -46,6 +48,15 @@ class Lock {
       this._redisConnection = redis.createClient(options.redis);
       this._redisSubscriber = redis.createClient(options.redis);
     }
+    /**
+     * Since subscriber client is created implicitly and
+     * it's being an instance of EventEmitter,
+     * we have to subscribe on error events in order to not
+     * cause crashes where this library is used.
+     *
+     * https://nodejs.org/api/events.html#error-events
+     */
+    this._redisSubscriber.on('error', noop);
 
     // Handler to run LUA scripts. Uses caching if possible
     this._scripty = new Scripty(this._redisConnection);


### PR DESCRIPTION
## 📚 Context/Description Behind The Change
Under the hood this package creates its own instance of redis client to subscribe on redis events. This client is an instance of EventEmitter and in case of errors it emits `error` event. When this event doesn't have at least one subscriber - Node.js process is crashed.

When using this library in some production service, it leads to uncontrolled crashes (no way to handled it via `process.on` listeners), so we have to add such listener here

## 🚨 Potential Risks & What To Monitor After Deployment
Don't see any

## 🧑‍🔬 How Has This Been Tested?
- [x] adding the same code directly on installed package and shutting down redis instance, verify service not crashed

## 🚚 Release Plan
Merge, get new version, bump everywhere in MM